### PR TITLE
fix: refresh profile metadata during background updates

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -358,6 +358,57 @@ pub async fn find_note(
     Ok(())
 }
 
+/// Fetch the latest profile metadata (kind 0) from relays and update nostrdb.
+///
+/// Profile metadata is a replaceable event (NIP-01) - nostrdb keeps only the
+/// newest version by `created_at` timestamp. This function queries relays for
+/// the latest kind 0 event to ensure cached profile data stays fresh during
+/// background refreshes.
+async fn fetch_profile_metadata(
+    relay_pool: Arc<RelayPool>,
+    ndb: Ndb,
+    relays: Arc<Vec<RelayUrl>>,
+    pubkey: [u8; 32],
+) {
+    use nostr_sdk::JsonUtil;
+
+    if relays.is_empty() {
+        return;
+    }
+
+    let filter = {
+        let author_ref = [&pubkey];
+        convert_filter(
+            &nostrdb::Filter::new()
+                .authors(author_ref)
+                .kinds([0])
+                .limit(1)
+                .build(),
+        )
+    };
+
+    let stream = relay_pool
+        .stream_events(vec![filter], &relays, Duration::from_millis(2000))
+        .await;
+
+    let mut stream = match stream {
+        Ok(s) => s,
+        Err(err) => {
+            warn!("failed to stream profile metadata: {err}");
+            return;
+        }
+    };
+
+    // Process all returned events - nostrdb handles deduplication and keeps newest.
+    // Note: we skip ensure_relay_hints here because kind 0 profile metadata doesn't
+    // contain relay hints (unlike kind 1 notes which may have 'r' tags).
+    while let Some(event) = stream.next().await {
+        if let Err(err) = ndb.process_event(&event.as_json()) {
+            error!("error processing profile metadata event: {err}");
+        }
+    }
+}
+
 pub async fn fetch_profile_feed(
     relay_pool: Arc<RelayPool>,
     ndb: Ndb,
@@ -366,6 +417,14 @@ pub async fn fetch_profile_feed(
     let relay_targets = collect_profile_relays(relay_pool.clone(), ndb.clone(), pubkey).await?;
 
     let relay_targets_arc = Arc::new(relay_targets);
+
+    // Spawn metadata fetch in parallel - best-effort, don't block note refresh
+    tokio::spawn(fetch_profile_metadata(
+        relay_pool.clone(),
+        ndb.clone(),
+        relay_targets_arc.clone(),
+        pubkey,
+    ));
 
     let cutoff = SystemTime::now()
         .checked_sub(Duration::from_secs(


### PR DESCRIPTION
## Summary

- Profile metadata (kind 0) was never refreshed after initial cache - background refresh only fetched notes (kind 1)
- Added `fetch_profile_metadata()` that runs in parallel with note fetching
- Best-effort: failures don't block note refresh, just log warnings

## Test plan

- [x] Verified locally - stale profiles now update on page visit
- [ ] Check logs for any "failed to stream profile metadata" warnings under normal operation

Fixes https://github.com/damus-io/notecrumbs/issues/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced profile loading by fetching profile metadata in parallel with profile feed data, reducing overall load time and improving responsiveness.
  * Simplified profile data retrieval by automating relay discovery internally, streamlining the data fetching process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->