### PR TITLE
feat: display direct replies below notes

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -1058,6 +1058,89 @@ fn author_handle_html(profile: Option<&ProfileRecord<'_>>) -> String {
         .unwrap_or_default()
 }
 
+/// Render a note preview as plain HTML text with mention resolution.
+///
+/// Iterates content blocks, resolving nprofile/npub mentions to `@DisplayName`
+/// and hashtags to `#tag`. Truncates to `max_chars` on block boundaries
+/// (never slices mid-mention) and appends "..." when truncated.
+pub fn render_note_preview_html(
+    note: &Note,
+    ndb: &Ndb,
+    txn: &Transaction,
+    max_chars: usize,
+) -> String {
+    let blocks = note
+        .key()
+        .and_then(|nk| ndb.get_blocks_by_key(txn, nk).ok());
+
+    let Some(blocks) = blocks else {
+        let content = abbreviate(note.content(), max_chars);
+        let truncated = content.len() < note.content().len();
+        let escaped = html_escape::encode_text(content);
+        if truncated {
+            return format!("{}...", escaped);
+        }
+        return escaped.into_owned();
+    };
+
+    let mut out = String::new();
+    let mut char_count = 0;
+    let mut truncated = false;
+
+    for block in blocks.iter(note) {
+        let fragment = match block.blocktype() {
+            BlockType::MentionBech32 => {
+                if let Some(mention) = block.as_mention() {
+                    match mention {
+                        Mention::Profile(nprofile) => {
+                            resolve_mention_name(ndb, txn, nprofile.pubkey(), block.as_str())
+                        }
+                        Mention::Pubkey(npub) => {
+                            resolve_mention_name(ndb, txn, npub.pubkey(), block.as_str())
+                        }
+                        _ => format!("@{}", abbrev_str(block.as_str())),
+                    }
+                } else {
+                    format!("@{}", abbrev_str(block.as_str()))
+                }
+            }
+            BlockType::Hashtag => format!("#{}", block.as_str()),
+            _ => block.as_str().to_owned(),
+        };
+
+        let fragment_chars = fragment.chars().count();
+        if char_count + fragment_chars > max_chars {
+            // For plain text blocks, include a truncated portion instead of
+            // dropping the entire block.
+            let remaining = max_chars - char_count;
+            if remaining > 0 && matches!(block.blocktype(), BlockType::Text) {
+                let partial: String = fragment.chars().take(remaining).collect();
+                let _ = write!(out, "{}", html_escape::encode_text(&partial));
+            }
+            truncated = true;
+            break;
+        }
+
+        let _ = write!(out, "{}", html_escape::encode_text(&fragment));
+        char_count += fragment_chars;
+    }
+
+    if truncated {
+        out.push_str("...");
+    }
+
+    out
+}
+
+/// Resolve a mention pubkey to `@DisplayName` or fall back to abbreviated bech32.
+fn resolve_mention_name(ndb: &Ndb, txn: &Transaction, pk: &[u8; 32], raw: &str) -> String {
+    let record = ndb.get_profile_by_pubkey(txn, pk).ok();
+    match get_profile_display_name(record.as_ref()) {
+        Some(name) => format!("@{}", name),
+        None => format!("@{}", abbrev_str(raw)),
+    }
+}
+
 /// Extracts parent note info for thread layout.
 /// Returns None if the note is not a reply.
 struct ParentNoteInfo {
@@ -1079,7 +1162,13 @@ fn get_parent_note_info(
     let reply_info = NoteReply::new(note.tags());
     let parent_ref = reply_info.reply().or_else(|| reply_info.root())?;
 
-    let link = EventId::from_byte_array(*parent_ref.id)
+    // Use nevent1 (with relay hint) instead of note1 for better discoverability
+    let event_id = EventId::from_byte_array(*parent_ref.id);
+    let mut nevent = Nip19Event::new(event_id);
+    if let Some(relay) = parent_ref.relay.and_then(|s| RelayUrl::parse(s).ok()) {
+        nevent = nevent.relays(std::iter::once(relay));
+    }
+    let link = nevent
         .to_bech32()
         .map(|b| format!("{}/{}", base_url, b))
         .unwrap_or_else(|_| "#".to_string());
@@ -1088,13 +1177,6 @@ fn get_parent_note_info(
         Ok(parent_note) => {
             let parent_profile = ndb.get_profile_by_pubkey(txn, parent_note.pubkey()).ok();
             let name = get_profile_display_name(parent_profile.as_ref()).unwrap_or("nostrich");
-
-            let content = abbreviate(parent_note.content(), 200);
-            let ellipsis = if content.len() < parent_note.content().len() {
-                "..."
-            } else {
-                ""
-            };
 
             let pfp = pfp_url_attr(
                 parent_profile.as_ref().and_then(|r| r.record().profile()),
@@ -1109,7 +1191,7 @@ fn get_parent_note_info(
                     parent_note.created_at(),
                 ))
                 .into_owned(),
-                content_html: format!("{}{}", html_escape::encode_text(content), ellipsis),
+                content_html: render_note_preview_html(&parent_note, ndb, txn, 200),
             })
         }
         Err(_) => {
@@ -1259,24 +1341,15 @@ fn build_replies_html(app: &Notecrumbs, txn: &Transaction, note: &Note, base_url
         let display_name = get_profile_display_name(profile_rec.as_ref()).unwrap_or("nostrich");
         let display_name_html = html_escape::encode_text(display_name);
 
-        let pfp_url = profile_rec
-            .as_ref()
-            .and_then(|r| r.record().profile())
-            .and_then(|p| p.picture())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("/img/no-profile.svg");
-        let pfp_attr = html_escape::encode_double_quoted_attribute(pfp_url);
+        let pfp_attr = pfp_url_attr(
+            profile_rec.as_ref().and_then(|r| r.record().profile()),
+            base_url,
+        );
 
         let time_str = format_relative_time(reply.created_at());
         let time_html = html_escape::encode_text(&time_str);
 
-        let content = abbreviate(reply.content(), 300);
-        let ellipsis = if content.len() < reply.content().len() {
-            "..."
-        } else {
-            ""
-        };
-        let content_html = format!("{}{}", html_escape::encode_text(content), ellipsis);
+        let content_html = render_note_preview_html(reply, &app.ndb, txn, 300);
 
         let reply_nevent = Nip19Event::new(EventId::from_byte_array(reply.id().to_owned()));
         let reply_id = reply_nevent.to_bech32().unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,6 +415,17 @@ async fn fetch_note_secondary_data(
         render::fetch_unknowns(relay_pool, ndb, unknowns).await?;
     }
 
+    // Fetch parent note content unknowns (profiles mentioned in parent)
+    if let Some(parent_unknowns) = render::collect_parent_unknowns(ndb, note_rd) {
+        tracing::debug!(
+            "fetching {} parent content unknowns",
+            parent_unknowns.ids_len()
+        );
+        if let Err(err) = render::fetch_unknowns(relay_pool, ndb, parent_unknowns).await {
+            tracing::warn!("failed to fetch parent unknowns: {err}");
+        }
+    }
+
     // Fetch note stats (reactions, replies, reposts)
     render::fetch_note_stats(relay_pool, ndb, note_rd, source_relays).await?;
 
@@ -426,6 +437,17 @@ async fn fetch_note_secondary_data(
         );
         if let Err(err) = render::fetch_unknowns(relay_pool, ndb, reply_unknowns).await {
             tracing::warn!("failed to fetch reply author profiles: {err}");
+        }
+    }
+
+    // Fetch profiles mentioned in reply content
+    if let Some(reply_content_unknowns) = render::collect_reply_content_unknowns(ndb, note_rd) {
+        tracing::debug!(
+            "fetching {} reply content unknowns",
+            reply_content_unknowns.ids_len()
+        );
+        if let Err(err) = render::fetch_unknowns(relay_pool, ndb, reply_content_unknowns).await {
+            tracing::warn!("failed to fetch reply content unknowns: {err}");
         }
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -684,6 +684,12 @@ pub fn collect_note_unknowns(
 }
 
 /// Fetch unknown IDs (quoted events, profiles) from relays using relay hints.
+/// Fetch unknown IDs (quoted events, profiles) from relays using relay hints.
+///
+/// Subscribes to ndb filters before fetching so we can wait for the writer
+/// thread to finish processing ingested events. Without this, process_event_with
+/// queues events asynchronously and they may not be queryable when the caller
+/// opens a transaction to render.
 pub async fn fetch_unknowns(
     relay_pool: &Arc<RelayPool>,
     ndb: &Ndb,
@@ -691,21 +697,33 @@ pub async fn fetch_unknowns(
 ) -> Result<()> {
     use nostr_sdk::JsonUtil;
 
-    // Collect relay hints before consuming unknowns
+    // Collect relay hints and needed profile pubkeys before consuming unknowns.
+    // Merge relay hints with default relays so hintless profiles (e.g. @npub
+    // with no relay hint) still get queried on default relays.
     let relay_hints = unknowns.relay_hints();
-    let relay_targets: Vec<RelayUrl> = if relay_hints.is_empty() {
-        relay_pool.default_relays().to_vec()
-    } else {
-        relay_hints.into_iter().collect()
+    let needed_profiles = unknowns.profile_pubkeys();
+    let relay_targets: Vec<RelayUrl> = {
+        let mut targets: Vec<RelayUrl> = relay_pool.default_relays().to_vec();
+        for hint in relay_hints {
+            if !targets.contains(&hint) {
+                targets.push(hint);
+            }
+        }
+        targets
     };
 
-    // Build and convert filters in one go (nostrdb::Filter is not Send)
-    let nostr_filters: Vec<nostr::Filter> = {
+    // Build ndb filters, subscribe, then convert for relay fetch.
+    // nostrdb::Filter is not Send, so everything stays in this sync block.
+    // Subscribe BEFORE fetching so the subscription catches ingested events.
+    let (nostr_filters, mut ndb_stream) = {
         let filters = unknowns.to_filters();
         if filters.is_empty() {
             return Ok(());
         }
-        filters.iter().map(convert_filter).collect()
+        let nostr_filters: Vec<nostr::Filter> = filters.iter().map(convert_filter).collect();
+        let sub_id = ndb.subscribe(&filters)?;
+        let stream = sub_id.stream(ndb).notes_per_await(4);
+        (nostr_filters, stream)
     };
 
     // Now we can await - nostrdb::Filter has been dropped
@@ -718,6 +736,7 @@ pub async fn fetch_unknowns(
     );
 
     // Stream with shorter timeout since these are secondary fetches
+    let mut ingested = 0usize;
     for filter in nostr_filters {
         let mut stream = relay_pool
             .stream_events(filter, &relay_targets, Duration::from_millis(1500))
@@ -730,11 +749,92 @@ pub async fn fetch_unknowns(
                 .unwrap_or_else(IngestMetadata::new);
             if let Err(err) = ndb.process_event_with(&relay_event.event.as_json(), ingest_meta) {
                 warn!("error processing quoted event: {err}");
+            } else {
+                ingested += 1;
+            }
+        }
+    }
+
+    // Wait for ndb writer thread to finish processing ingested events.
+    // Use semantic readiness: check that needed profiles are actually queryable
+    // via get_profile_by_pubkey, not just count-based.
+    if ingested > 0 {
+        let wait_for = Duration::from_millis(500);
+        while let Ok(Some(_note_keys)) = timeout(wait_for, ndb_stream.next()).await {
+            if profiles_ready(ndb, &needed_profiles) {
+                break;
             }
         }
     }
 
     Ok(())
+}
+
+/// Check whether all needed profiles are queryable in ndb.
+fn profiles_ready(ndb: &Ndb, pubkeys: &[[u8; 32]]) -> bool {
+    if pubkeys.is_empty() {
+        return true;
+    }
+    let Ok(txn) = Transaction::new(ndb) else {
+        return false;
+    };
+    pubkeys
+        .iter()
+        .all(|pk| ndb.get_profile_by_pubkey(&txn, pk).is_ok())
+}
+
+/// Collect unknowns from the parent note's content blocks.
+/// Call this after the initial unknowns fetch so the parent note is in ndb.
+pub fn collect_parent_unknowns(
+    ndb: &Ndb,
+    note_rd: &NoteRenderData,
+) -> Option<crate::unknowns::UnknownIds> {
+    let txn = Transaction::new(ndb).ok()?;
+    let note = note_rd.lookup(&txn, ndb).ok()?;
+
+    use nostrdb::NoteReply;
+    let reply_info = NoteReply::new(note.tags());
+    let parent_ref = reply_info.reply().or_else(|| reply_info.root())?;
+    let parent_note = ndb.get_note_by_id(&txn, parent_ref.id).ok()?;
+
+    let mut unknowns = crate::unknowns::UnknownIds::new();
+    unknowns.add_profile_if_missing(ndb, &txn, parent_note.pubkey());
+    unknowns.collect_from_blocks(ndb, &txn, &parent_note);
+
+    if unknowns.is_empty() {
+        None
+    } else {
+        Some(unknowns)
+    }
+}
+
+/// Collect unknown profiles mentioned in reply note content blocks.
+/// Iterates replies already ingested in ndb and calls collect_from_blocks on each.
+pub fn collect_reply_content_unknowns(
+    ndb: &Ndb,
+    note_rd: &NoteRenderData,
+) -> Option<crate::unknowns::UnknownIds> {
+    let txn = Transaction::new(ndb).ok()?;
+    let note = note_rd.lookup(&txn, ndb).ok()?;
+
+    let filter = nostrdb::Filter::new()
+        .kinds([1])
+        .event(note.id())
+        .limit(DIRECT_REPLY_LIMIT as u64)
+        .build();
+    let results = ndb.query(&txn, &[filter], DIRECT_REPLY_LIMIT).ok()?;
+
+    let mut unknowns = crate::unknowns::UnknownIds::new();
+
+    for result in &results {
+        unknowns.collect_from_blocks(ndb, &txn, &result.note);
+    }
+
+    if unknowns.is_empty() {
+        None
+    } else {
+        Some(unknowns)
+    }
 }
 
 /// Fetch kind:7 reactions for a note from relays and ingest into ndb.
@@ -768,6 +868,11 @@ pub fn collect_reply_unknowns(
 }
 
 /// Fetch note stats (reactions, replies, reposts) from relays and ingest into ndb.
+///
+/// Subscribes to the reply (kind:1) filter before fetching so we can wait for
+/// the ndb writer thread to fully process reply events (including block parsing).
+/// Without this, `collect_reply_content_unknowns` may not find blocks for replies,
+/// causing mention profiles in reply content to never be fetched.
 pub async fn fetch_note_stats(
     relay_pool: &Arc<RelayPool>,
     ndb: &Ndb,
@@ -776,17 +881,25 @@ pub async fn fetch_note_stats(
 ) -> Result<()> {
     use nostr_sdk::JsonUtil;
 
-    // Build filters for reactions (kind:7), replies (kind:1), and reposts (kind:6)
-    // nostrdb::Filter is not Send, so convert before await
-    let filters: Vec<nostr::Filter> = {
+    // Build filters for reactions (kind:7), replies (kind:1), and reposts (kind:6).
+    // Subscribe to the reply filter before fetching so we catch writer notifications.
+    // nostrdb::Filter is not Send, so everything stays in this sync block.
+    let (filters, mut reply_stream) = {
         let txn = Transaction::new(ndb)?;
         let note = note_rd.lookup(&txn, ndb)?;
         let id = note.id();
-        vec![
+
+        // Subscribe to reply filter so we know when replies are fully indexed
+        let reply_filter = nostrdb::Filter::new().kinds([1]).event(id).build();
+        let sub_id = ndb.subscribe(&[reply_filter])?;
+        let stream = sub_id.stream(ndb).notes_per_await(2);
+
+        let nostr_filters = vec![
             convert_filter(&nostrdb::Filter::new().kinds([7]).event(id).build()),
             convert_filter(&nostrdb::Filter::new().kinds([1]).event(id).build()),
             convert_filter(&nostrdb::Filter::new().kinds([6]).event(id).build()),
-        ]
+        ];
+        (nostr_filters, stream)
     };
 
     let relay_targets: Vec<RelayUrl> = if source_relays.is_empty() {
@@ -799,18 +912,42 @@ pub async fn fetch_note_stats(
 
     debug!("fetching note stats from {:?}", relay_targets);
 
+    let mut reply_ingested = 0usize;
     for filter in filters {
         let mut stream = relay_pool
             .stream_events(filter, &relay_targets, Duration::from_millis(1500))
             .await?;
 
         while let Some(relay_event) = stream.next().await {
+            let is_reply = relay_event.event.kind == Kind::TextNote;
             let ingest_meta = relay_event
                 .relay_url()
                 .map(|url| IngestMetadata::new().relay(url.as_str()))
                 .unwrap_or_else(IngestMetadata::new);
-            if let Err(err) = ndb.process_event_with(&relay_event.event.as_json(), ingest_meta) {
-                warn!("error processing event: {err}");
+            match ndb.process_event_with(&relay_event.event.as_json(), ingest_meta) {
+                Ok(_) if is_reply => {
+                    reply_ingested += 1;
+                }
+                Err(err) => {
+                    warn!("error processing event: {err}");
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Wait for ndb writer to fully process reply events (including block parsing).
+    // The subscription fires after each event is fully indexed, so once we've seen
+    // all ingested replies, their blocks are guaranteed to be available.
+    if reply_ingested > 0 {
+        let wait_for = Duration::from_millis(500);
+        let mut seen = 0;
+        while seen < reply_ingested {
+            match timeout(wait_for, reply_stream.next()).await {
+                Ok(Some(note_keys)) => {
+                    seen += note_keys.len();
+                }
+                _ => break,
             }
         }
     }

--- a/src/unknowns.rs
+++ b/src/unknowns.rs
@@ -68,6 +68,17 @@ impl UnknownIds {
         self.ids.entry(unknown_id).or_default();
     }
 
+    /// Returns the profile pubkeys from the unknowns collection.
+    pub fn profile_pubkeys(&self) -> Vec<[u8; 32]> {
+        self.ids
+            .keys()
+            .filter_map(|id| match id {
+                UnknownId::Profile(pk) => Some(*pk),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Collect all relay hints from unknowns.
     pub fn relay_hints(&self) -> HashSet<RelayUrl> {
         self.ids
@@ -197,7 +208,7 @@ impl UnknownIds {
     }
 
     /// Collect unknowns from content blocks (mentions).
-    fn collect_from_blocks(&mut self, ndb: &Ndb, txn: &Transaction, note: &Note) {
+    pub fn collect_from_blocks(&mut self, ndb: &Ndb, txn: &Transaction, note: &Note) {
         let Some(note_key) = note.key() else {
             return;
         };


### PR DESCRIPTION
## Summary
- Display direct replies below notes with author avatar, name, timestamp, and content preview
- Resolve `@nprofile`/`@npub` mentions to display names in reply and parent previews
- Use `nevent1` (with relay hints) instead of `note1` for parent note links
- Wait for ndb writer thread to fully process reply events before extracting mention profiles

## Test plan
- [ ] Load a note with replies containing `@nprofile` mentions — verify display names render, not raw bech32
- [ ] Click parent note link — verify URL uses `nevent1` with relay hint, not `note1`
- [ ] Load a reply note — verify parent preview shows full content, not just first mention
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer note previews: mentions show display names (fallback to abbreviated IDs), hashtags rendered, and previews truncated cleanly with "..." when shortened.

* **Improvements**
  * More reliable background fetching so parent notes, reply content, and profiles are retrieved before display.
  * Replies show improved preview content and avatar selection for more accurate rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->